### PR TITLE
fix: height of desktop mail view, somehow got removed.

### DIFF
--- a/components/mail/mail.tsx
+++ b/components/mail/mail.tsx
@@ -137,7 +137,7 @@ export function Mail({ mails }: MailProps) {
             className="hidden md:block"
           >
             {/* Desktop Mail Display */}
-            <div className="hidden flex-1 overflow-y-auto md:block">
+            <div className="hidden h-full flex-1 overflow-y-auto md:block">
               <MailDisplay mail={filteredMails.find((item) => item.id === mail.selected) || null} />
             </div>
           </ResizablePanel>


### PR DESCRIPTION
a quick fix for the height of the mail view

somehow reverted to this:

<img width="2056" alt="Screenshot 2025-02-07 at 00 30 07" src="https://github.com/user-attachments/assets/a1a0916b-a0bc-4a3a-82f4-3a9302111622" />

fixed to be like this:
<img width="2056" alt="Screenshot 2025-02-07 at 00 30 04" src="https://github.com/user-attachments/assets/541da209-4c97-4408-b0de-32bac9528a38" />
