### PR TITLE
fix: load posthog only if key is present to prevent error in dev

### DIFF
--- a/providers/providers.tsx
+++ b/providers/providers.tsx
@@ -6,8 +6,8 @@ import { PostHogProvider } from "posthog-js/react";
 import posthog from "posthog-js";
 import * as React from "react";
 
-if (typeof window !== "undefined") {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
   });


### PR DESCRIPTION
prevents posthog from doing init if there is no key, otherwise there are errors in local development where people don't specify a key
Also there is no reason for most people to setup posthog in dev mode.

Edit: waiting on #39 to be merged first to fix CI issues before rebasing and merging this one