### PR TITLE
fix(ui): Added a `DialogTitle` to the `Command` component

### DIFF
--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { type DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
+
 import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import * as React from "react";
@@ -25,6 +26,7 @@ Command.displayName = CommandPrimitive.displayName;
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
+      <DialogTitle></DialogTitle>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}


### PR DESCRIPTION
This was causing an error before

* **Error:**
    ![Error](https://github.com/user-attachments/assets/063e9ba1-99cf-45f8-8138-f8c27e3a8bea)

*   **After:** (no visual changes)
    ![After](https://github.com/user-attachments/assets/972c7145-7c5b-42dd-bdef-310fff72ee41)
    
