### PR TITLE
Persist sidebar state through cookie

### DIFF
--- a/components/context/sidebar-context.tsx
+++ b/components/context/sidebar-context.tsx
@@ -57,12 +57,9 @@ export const SidebarProvider = React.forwardRef<
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
 
-    const sidebarCookie = getCookie(SIDEBAR_COOKIE_NAME);
-    // validate string === true because cookie value is returned as a string.
-    const isDefaultOpen = sidebarCookie ? sidebarCookie === "true" : defaultOpen;
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(isDefaultOpen);
+    const [_open, _setOpen] = React.useState(defaultOpen);
     const open = openProp ?? _open;
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
@@ -83,6 +80,13 @@ export const SidebarProvider = React.forwardRef<
     const toggleSidebar = React.useCallback(() => {
       return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
     }, [isMobile, setOpen, setOpenMobile]);
+
+    React.useEffect(() => {
+      // In nextjs, browser apis are guarded so we need to do this in a use effect to not get an error that document is not defined.
+      const sidebarCookie = getCookie(SIDEBAR_COOKIE_NAME);
+      const isDefaultOpen = sidebarCookie ? sidebarCookie === "true" : defaultOpen;
+      _setOpen(isDefaultOpen);
+    }, []);
 
     // Adds a keyboard shortcut to toggle the sidebar.
     React.useEffect(() => {

--- a/components/context/sidebar-context.tsx
+++ b/components/context/sidebar-context.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/constants";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { TooltipProvider } from "../ui/tooltip";
+import { getCookie } from "@/utils/cookies";
 import { cn } from "@/lib/utils";
 import * as React from "react";
 
@@ -56,9 +57,12 @@ export const SidebarProvider = React.forwardRef<
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
 
+    const sidebarCookie = getCookie(SIDEBAR_COOKIE_NAME);
+    // validate string === true because cookie value is returned as a string.
+    const isDefaultOpen = sidebarCookie ? sidebarCookie === "true" : defaultOpen;
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen);
+    const [_open, _setOpen] = React.useState(isDefaultOpen);
     const open = openProp ?? _open;
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/utils/cookies.ts
+++ b/utils/cookies.ts
@@ -1,7 +1,6 @@
-export const getCookie = (key: string): string => {
-  const cookies = Object.fromEntries(
+export const getCookie = (key: string): string | null => {
+  const _cookies = Object.fromEntries(
     document.cookie.split("; ").map((v) => v.split(/=(.*)/s).map(decodeURIComponent)),
   );
-
-  return cookies?.[key] ?? null;
+  return _cookies?.[key] ?? null;
 };

--- a/utils/cookies.ts
+++ b/utils/cookies.ts
@@ -1,0 +1,7 @@
+export const getCookie = (key: string): string => {
+  const cookies = Object.fromEntries(
+    document.cookie.split("; ").map((v) => v.split(/=(.*)/s).map(decodeURIComponent)),
+  );
+
+  return cookies?.[key] ?? null;
+};

--- a/utils/cookies.ts
+++ b/utils/cookies.ts
@@ -1,6 +1,6 @@
 export const getCookie = (key: string): string | null => {
-  const _cookies = Object.fromEntries(
+  const cookies = Object.fromEntries(
     document.cookie.split("; ").map((v) => v.split(/=(.*)/s).map(decodeURIComponent)),
   );
-  return _cookies?.[key] ?? null;
+  return cookies?.[key] ?? null;
 };


### PR DESCRIPTION
Fixes #26 

Correctly use the cookie value to restore the sidebar state to the user's last used state.

If there is no cookie, it will default to the `defaultOpen` prop.
I added a comment to explain why it's done in a `useEffect`.
Unfortunately there is a slight flicker of the sidebar until the onMount useEffect runs if the cookie does not match the `defaultOpen` prop.

Nextjs guards browser apis even on client components so the only safe way to access the cookie is in a useEffect.

Open to alternative if you know better