### PR TITLE
Fix: Adjusted ScrollArea height fixing the issues outlined in #60

### DIFF
--- a/components/mail/mail-list.tsx
+++ b/components/mail/mail-list.tsx
@@ -32,8 +32,8 @@ export function MailList({ items, isCompact, onMailClick }: MailListProps) {
   };
 
   return (
-    <ScrollArea className="mt-4 h-[calc(100vh-13rem-1px)]" type="auto">
-      <div className="flex flex-col gap-2 p-4 pt-0">
+    <ScrollArea className="h-[calc(100dvh-8rem-1px)]" type="auto">
+      <div className="mt-4 flex flex-col gap-2 p-4 pt-0">
         {items.map((item) => (
           <div
             key={item.id}


### PR DESCRIPTION
Manually adjusting the `ScrollArea` height is a frustrating but necessary fix for now, as this pull request implements the tedious method. The issue seems to stem from the `TabList` component, and as the app grows, this approach will become increasingly unmanageable. I suggest we revisit this later—keeping the tab selector UI intact but handling the tab content display ourselves without relying on ShadCN.