### PR TITLE
feat (ui): add auto save id to panel group for auto saving layout sizes

### DIFF
--- a/components/mail/mail.tsx
+++ b/components/mail/mail.tsx
@@ -65,7 +65,7 @@ export function Mail({ mails }: MailProps) {
   return (
     <TooltipProvider delayDuration={0}>
       <div className="flex h-dvh">
-        <ResizablePanelGroup direction="horizontal">
+        <ResizablePanelGroup direction="horizontal" autoSaveId={"mail-panel-layout"}>
           <ResizablePanel defaultSize={isMobile ? 100 : 25} minSize={isMobile ? 100 : 25}>
             <div className="flex-1 overflow-y-auto border-r">
               <Tabs defaultValue="all">

--- a/components/mail/mail.tsx
+++ b/components/mail/mail.tsx
@@ -20,7 +20,6 @@ import { tagsAtom } from "@/components/mail/use-tags";
 import { SidebarToggle } from "../ui/sidebar-toggle";
 import { type Mail } from "@/components/mail/data";
 import Filters from "@/components/mail/filters";
-import { Input } from "@/components/ui/input";
 import { useAtomValue } from "jotai";
 
 interface MailProps {


### PR DESCRIPTION
Added `autoSaveId={"mail-panel-layout"}` to the `ResizablePanelGroup` for autosaving functionality built into shadcn `Resizable`