### PR TITLE
feat: add popover for security information in mail display

### DIFF
--- a/components/mail/mail-display.tsx
+++ b/components/mail/mail-display.tsx
@@ -208,32 +208,32 @@ export function MailDisplay({ mail }: MailDisplayProps) {
                   </PopoverTrigger>
                   <PopoverContent className="w-[320px] space-y-2" align="start">
                     {/* TODO: Content is currently dummy and uses mail.email for all of them. need to add other values to email type */}
-                    <div className="line-clamp-1 text-xs">
+                    <div className="text-xs">
                       <span className="font-medium text-muted-foreground">From:</span> {mail.email}
                     </div>
-                    <div className="line-clamp-1 text-xs">
+                    <div className="text-xs">
                       <span className="font-medium text-muted-foreground">Reply-To:</span>{" "}
                       {mail.email}
                     </div>
-                    <div className="line-clamp-1 text-xs">
+                    <div className="text-xs">
                       <span className="font-medium text-muted-foreground">To:</span> {mail.email}
                     </div>
-                    <div className="line-clamp-1 text-xs">
+                    <div className="text-xs">
                       <span className="font-medium text-muted-foreground">Cc:</span> {mail.email}
                     </div>
-                    <div className="line-clamp-1 text-xs">
+                    <div className="text-xs">
                       <span className="font-medium text-muted-foreground">Date:</span>{" "}
                       {format(new Date(mail.date), "PPpp")}
                     </div>
-                    <div className="line-clamp-1 text-xs">
+                    <div className="text-xs">
                       <span className="font-medium text-muted-foreground">Mailed-By:</span>{" "}
                       {mail.email}
                     </div>
-                    <div className="line-clamp-1 text-xs">
+                    <div className="text-xs">
                       <span className="font-medium text-muted-foreground">Signed-By:</span>{" "}
                       {mail.email}
                     </div>
-                    <div className="line-clamp-1 text-xs">
+                    <div className="flex items-center gap-1 text-xs">
                       <span className="font-medium text-muted-foreground">Security:</span>{" "}
                       <Lock className="h-3 w-3" /> {mail.email}
                     </div>

--- a/components/mail/mail-display.tsx
+++ b/components/mail/mail-display.tsx
@@ -11,6 +11,7 @@ import {
   Trash2,
   BellOff,
   X,
+  Lock,
 } from "lucide-react";
 import { nextSaturday } from "date-fns/nextSaturday";
 import { addHours } from "date-fns/addHours";
@@ -193,15 +194,51 @@ export function MailDisplay({ mail }: MailDisplayProps) {
                 </AvatarFallback>
               </Avatar>
               <div className="grid gap-1">
-                <div className="font-semibold">{mail.name}</div>
+                <div className="font-semibold">
+                  {mail.name} <span className="text-muted-foreground">&lt;{mail.email}&gt;</span>
+                </div>
                 {/* Display the subject with the muted icon if isMuted is true */}
                 <div className="line-clamp-1 flex items-center text-xs">
                   {mail.subject}
                   {isMuted && <BellOff className="ml-2 h-4 w-4 text-muted-foreground" />}
                 </div>
-                <div className="line-clamp-1 text-xs">
-                  <span className="font-medium">Reply-To:</span> {mail.email}
-                </div>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <span className="cursor-pointer text-xs underline">Details</span>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[320px] space-y-2" align="start">
+                    {/* TODO: Content is currently dummy and uses mail.email for all of them. need to add other values to email type */}
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">From:</span> {mail.email}
+                    </div>
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">Reply-To:</span>{" "}
+                      {mail.email}
+                    </div>
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">To:</span> {mail.email}
+                    </div>
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">Cc:</span> {mail.email}
+                    </div>
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">Date:</span>{" "}
+                      {format(new Date(mail.date), "PPpp")}
+                    </div>
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">Mailed-By:</span>{" "}
+                      {mail.email}
+                    </div>
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">Signed-By:</span>{" "}
+                      {mail.email}
+                    </div>
+                    <div className="line-clamp-1 text-xs">
+                      <span className="font-medium text-muted-foreground">Security:</span>{" "}
+                      <Lock className="h-3 w-3" /> {mail.email}
+                    </div>
+                  </PopoverContent>
+                </Popover>
               </div>
             </div>
             {mail.date && (


### PR DESCRIPTION
Tidied up `mail-display.tsx` but some issues explained below -

Needs some work on mobile - anybody feel free to make changes and improve:
<img width="430" alt="Screenshot 2025-02-08 at 14 24 58" src="https://github.com/user-attachments/assets/a8427872-e8f8-46a4-b24f-fe05a00e65c3" />

`line-clamp-1` is annoying me and I'm not sure how to best work around this part.
<img width="463" alt="Screenshot 2025-02-08 at 14 46 48" src="https://github.com/user-attachments/assets/5c65fd60-b9bc-4ba3-a81a-0b4f7a88f3f1" />
<img width="427" alt="Screenshot 2025-02-08 at 14 46 57" src="https://github.com/user-attachments/assets/3edabb78-220e-4581-9c26-47301c45f063" />
