### PR TITLE
feat(attachments): add tooltip with full filename

### DIFF
--- a/components/mail/mail-compose.tsx
+++ b/components/mail/mail-compose.tsx
@@ -22,6 +22,7 @@ interface MailComposeProps {
   };
 }
 
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@radix-ui/react-tooltip";
 import { Popover, PopoverTrigger, PopoverContent } from "../ui/popover";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { useOpenComposeModal } from "@/hooks/use-open-compose-modal";
@@ -121,20 +122,29 @@ export function MailCompose({ onClose, replyTo }: MailComposeProps) {
     return (
       <div className="mx-auto mt-2 flex w-[95%] flex-wrap gap-2">
         {attachments.slice(0, MAX_VISIBLE_ATTACHMENTS).map((file, index) => (
-          <Badge key={index} variant="secondary">
-            {truncateFileName(file.name)}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="-mr-1 ml-2 h-5 w-5 rounded-full p-0"
-              onClick={(e) => {
-                e.preventDefault();
-                removeAttachment(index);
-              }}
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </Badge>
+          <TooltipProvider key={index}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge variant="secondary">
+                  {truncateFileName(file.name)}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="-mr-1 ml-2 h-5 w-5 rounded-full p-0"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      removeAttachment(index);
+                    }}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent className="bg-popover">
+                <p className="z-50">{file.name}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ))}
 
         {hasHiddenAttachments && (

--- a/components/mail/mail-compose.tsx
+++ b/components/mail/mail-compose.tsx
@@ -141,7 +141,7 @@ export function MailCompose({ onClose, replyTo }: MailComposeProps) {
                 </Badge>
               </TooltipTrigger>
               <TooltipContent className="bg-popover">
-                <p className="z-50">{file.name}</p>
+                <p className="z-50">{truncateFileName(file.name, 100)}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/components/mail/mail-display.tsx
+++ b/components/mail/mail-display.tsx
@@ -1,7 +1,6 @@
 import {
   Archive,
   ArchiveX,
-  ArrowUp,
   Clock,
   Forward,
   MoreVertical,
@@ -19,10 +18,10 @@ import { useState, useEffect } from "react";
 import { addDays } from "date-fns/addDays";
 import { format } from "date-fns/format";
 
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { DropdownMenu, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
@@ -301,20 +300,29 @@ export function MailDisplay({ mail }: MailDisplayProps) {
                 <div className="box-border py-4">
                   <div className="flex flex-wrap gap-2">
                     {attachments.map((file, index) => (
-                      <Badge key={index} variant="default">
-                        {truncateFileName(file.name)}
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="-mr-1 ml-2 h-5 w-5 rounded-full p-0"
-                          onClick={(e) => {
-                            e.preventDefault();
-                            removeAttachment(index);
-                          }}
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </Badge>
+                      <TooltipProvider key={index}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge variant="default">
+                              {truncateFileName(file.name)}
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="-mr-1 ml-2 h-5 w-5 rounded-full p-0"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  removeAttachment(index);
+                                }}
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p className="z-50">{file.name}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                     ))}
                   </div>
                 </div>

--- a/components/mail/mail-display.tsx
+++ b/components/mail/mail-display.tsx
@@ -319,7 +319,7 @@ export function MailDisplay({ mail }: MailDisplayProps) {
                             </Badge>
                           </TooltipTrigger>
                           <TooltipContent>
-                            <p className="z-50">{file.name}</p>
+                            <p className="z-50">{truncateFileName(file.name, 100)}</p>
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>


### PR DESCRIPTION
Adds a tooltip to reveal the full name of an attachment, useful for when you have multiple files with similar names and would like to remove a spesific one.

Looks like this:

![image](https://github.com/user-attachments/assets/833be4a2-8836-4bf8-b170-f91f05b95052)
