### PR TITLE
fix: add filename truncation back

### DIFF
--- a/components/mail/mail-compose.tsx
+++ b/components/mail/mail-compose.tsx
@@ -176,7 +176,7 @@ export function MailCompose({ onClose, replyTo }: MailComposeProps) {
                   )}
                 </div>
                 <div className="bg-secondary p-2">
-                  <p className="text-sm font-medium">{file.name}</p>
+                  <p className="text-sm font-medium">{truncateFileName(file.name, 30)}</p>
                   <p className="text-xs text-muted-foreground">
                     Size: {(file.size / (1024 * 1024)).toFixed(2)} MB
                   </p>

--- a/components/mail/mail-display.tsx
+++ b/components/mail/mail-display.tsx
@@ -301,7 +301,7 @@ export function MailDisplay({ mail, onClose }: MailDisplayProps) {
                             )}
                           </div>
                           <div className="bg-secondary p-2">
-                            <p className="text-sm font-medium">{file.name}</p>
+                            <p className="text-sm font-medium">{truncateFileName(file.name, 30)}</p>
                             <p className="text-xs text-muted-foreground">
                               Size: {(file.size / (1024 * 1024)).toFixed(2)} MB
                             </p>


### PR DESCRIPTION
In a previous commit by @HSp4m they removed the truncation of the filename in the attachment tooltip. This makes it looks weird when a filename is really long. Thats why I added back truncation to prevent it from looking weird!

Current: 
![image](https://github.com/user-attachments/assets/593fc96e-d5ee-45a7-b7ff-7accfcf9fa4a)

Now: 
![image](https://github.com/user-attachments/assets/30da40c6-6efd-4d7f-bdbe-ed53951fb815)
