### PR TITLE
feat: implement search logic

### DIFF
--- a/components/mail/mail.tsx
+++ b/components/mail/mail.tsx
@@ -26,6 +26,7 @@ import { useMediaQuery } from "../../hooks/use-media-query";
 import { tagsAtom } from "@/components/mail/use-tags";
 import { SidebarToggle } from "../ui/sidebar-toggle";
 import { type Mail } from "@/components/mail/data";
+import { useSearch } from "./use-search";
 import { SearchBar } from "./search-bar";
 import { useAtomValue } from "jotai";
 
@@ -47,12 +48,12 @@ export function Mail({ mails }: MailProps) {
   const [isCompact, setIsCompact] = React.useState(false);
   const tags = useAtomValue(tagsAtom);
   const activeTags = tags.filter((tag) => tag.checked);
+  const [searchFilters, setSearchFilters] = useSearch();
 
-  const filteredMails = useFilteredMails(mails, activeTags);
+  const filteredMails = useFilteredMails(mails, activeTags, searchFilters);
 
   const [, setIsDialogOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const [filterValue, setFilterValue] = useState<"all" | "unread">("all");
   const [open, setOpen] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
 
@@ -121,10 +122,18 @@ export function Mail({ mails }: MailProps) {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          <DropdownMenuItem onClick={() => setFilterValue("all")}>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              setSearchFilters((prev) => ({ ...prev, readFilter: "all" }))
+                            }
+                          >
                             All mail
                           </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => setFilterValue("unread")}>
+                          <DropdownMenuItem
+                            onClick={() =>
+                              setSearchFilters((prev) => ({ ...prev, readFilter: "unread" }))
+                            }
+                          >
                             Unread
                           </DropdownMenuItem>
                         </DropdownMenuContent>
@@ -135,7 +144,7 @@ export function Mail({ mails }: MailProps) {
                 </div>
 
                 <div className="h-[calc(93vh)]">
-                  {filterValue === "all" ? (
+                  {searchFilters.readFilter === "all" ? (
                     filteredMails.length === 0 ? (
                       <div className="p-8 text-center text-muted-foreground">
                         No messages found | Clear filters to see more results

--- a/components/mail/use-search.ts
+++ b/components/mail/use-search.ts
@@ -1,0 +1,32 @@
+import type { DateRange } from "react-day-picker";
+import { atom, useAtom } from "jotai";
+
+export const INBOXES = ["All Mail", "Inbox", "Drafts", "Sent", "Junk", "Trash", "Archive"] as const;
+
+export type Inbox = (typeof INBOXES)[number];
+
+export interface SearchFilters {
+  query: string;
+  subject: string;
+  from: string;
+  to: string;
+  inbox: Inbox;
+  dateRange?: DateRange;
+  readFilter: "all" | "unread";
+}
+
+export const INITIAL_FILTERS: SearchFilters = {
+  query: "",
+  subject: "",
+  from: "",
+  to: "",
+  inbox: "All Mail",
+  dateRange: undefined,
+  readFilter: "all",
+};
+
+export const searchFiltersAtom = atom<SearchFilters>(INITIAL_FILTERS);
+
+export function useSearch() {
+  return useAtom(searchFiltersAtom);
+}

--- a/hooks/use-filtered-mails.ts
+++ b/hooks/use-filtered-mails.ts
@@ -1,14 +1,25 @@
+import { SearchFilters } from "@/components/mail/use-search";
 import { Tag } from "@/components/mail/use-tags";
 import { Mail } from "@/components/mail/data";
 import { useMemo } from "react";
+
+function composePredicates<T>(predicates: ((item: T) => boolean)[]): (item: T) => boolean {
+  return (item: T) => predicates.every((predicate) => predicate(item));
+}
 
 /**
  * Custom hook for filtering mails based on active tags
  * @param mails - Array of mail objects to filter
  * @param activeTags - Array of currently active tag objects
+ * @param searchFilters - Search filters set in the search bar
+ * @param readFilter
  * @returns Array of filtered mail objects
  */
-export const useFilteredMails = (mails: Mail[], activeTags: Tag[]) => {
+export const useFilteredMails = (
+  mails: Mail[],
+  activeTags: Tag[],
+  searchFilters: SearchFilters,
+) => {
   // Create a lookup object for active tags
   const activeTagLookup = useMemo(() => {
     const lookup: Record<string, boolean> = {};
@@ -18,13 +29,47 @@ export const useFilteredMails = (mails: Mail[], activeTags: Tag[]) => {
     return lookup;
   }, [activeTags]);
 
-  // Filter mails based on active tags
   const filteredMails = useMemo(() => {
-    if (activeTags.length === 0) return mails;
+    const predicates: ((mail: Mail) => boolean)[] = [];
 
-    return mails.filter((mail) =>
-      mail.labels.some((label) => activeTagLookup[label.toLowerCase()]),
-    );
+    if (activeTags.length > 0) {
+      predicates.push((mail: Mail) =>
+        mail.labels.some((label) => activeTagLookup[label.toLowerCase()]),
+      );
+    }
+
+    if (searchFilters.query) {
+      const queryLower = searchFilters.query.toLowerCase();
+      predicates.push((mail: Mail) => {
+        const content = (mail.subject + " " + mail.email + " " + (mail.text ?? "")).toLowerCase();
+        return content.includes(queryLower);
+      });
+    }
+
+    if (searchFilters.subject) {
+      const subjectLower = searchFilters.subject.toLowerCase();
+      predicates.push((mail: Mail) => mail.subject.toLowerCase().includes(subjectLower));
+    }
+    if (searchFilters.from) {
+      const fromLower = searchFilters.from.toLowerCase();
+      predicates.push((mail: Mail) => mail.email.toLowerCase().includes(fromLower));
+    }
+
+    if (searchFilters.dateRange && searchFilters.dateRange.from && searchFilters.dateRange.to) {
+      const { from: startDate, to: endDate } = searchFilters.dateRange;
+      predicates.push((mail: Mail) => {
+        const mailDate = new Date(mail.date);
+        return mailDate >= startDate && mailDate <= endDate;
+      });
+    }
+
+    if (searchFilters.readFilter === "unread") {
+      predicates.push((mail: Mail) => !mail.read);
+    }
+
+    const combinedPredicate = composePredicates(predicates);
+
+    return mails.filter(combinedPredicate);
   }, [mails, activeTagLookup, activeTags.length]);
 
   return filteredMails;


### PR DESCRIPTION
#### Summary  
This PR implements the logic for the search bar and search filters, making them functional. Previously, they were just UI elements without actual filtering.  

#### Changes  
- **Search Bar Logic:** Now filters emails based on input queries.  
- **Filters Functionality:**  
  - The filters inside the popover (triggered via the search bar) now work.  
  - Applied filters include subject, recipient, and date range.  
- **Popover Behavior Fix:** The popover now closes when clicking "Apply Filters."  

#### Known Limitations  
- The **inbox selection filter** is currently not functional.  
- The **labels filter** has not been integrated yet - I assume it should trigger some tag-based filtering, but that needs clarification.  