### PR TITLE
fix: textarea background color to match theme color

### DIFF
--- a/components/mail/mail-display.tsx
+++ b/components/mail/mail-display.tsx
@@ -287,7 +287,7 @@ export function MailDisplay({ mail, onClose, isMobile }: MailDisplayProps) {
               </div>
 
               <Textarea
-                className="min-h-[60px] w-full resize-none border-0 bg-[#18181A] leading-relaxed placeholder:text-muted-foreground/70 focus-visible:ring-0 focus-visible:ring-offset-0 md:text-base"
+                className="min-h-[60px] w-full resize-none border-0 bg-[#FAFAFA] leading-relaxed placeholder:text-muted-foreground/70 focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-[#18181A] md:text-base"
                 placeholder="Write your reply..."
                 spellCheck={true}
                 autoFocus


### PR DESCRIPTION
This PR fixes the textarea background color to properly support both light and dark themes.

Changes:
- Added `bg-[#FAFAFA]` for light theme
- Added `dark:bg-[#18181A]` for dark theme to maintain contrast

This adds proper visibility of text in for both themes.