### PR TITLE
Fix multi account logout

### DIFF
--- a/app/(full-width)/connect-emails/page.tsx
+++ b/app/(full-width)/connect-emails/page.tsx
@@ -53,14 +53,14 @@ export default function ConnectEmails() {
 
   return (
     <div className="flex h-dvh w-screen items-center justify-center bg-background">
-      <div className="flex w-full max-w-md flex-col gap-2 overflow-hidden rounded-2xl">
-        <div className="flex flex-col items-center justify-center gap-1 px-4 text-center sm:px-16">
+      <div className="flex w-full max-w-sm flex-col gap-2 overflow-hidden rounded-2xl">
+        <div className="flex flex-col items-center justify-center gap-1 px-4 text-center">
           <h3 className="text-xl font-semibold dark:text-zinc-50">Connect your emails</h3>
           <p className="text-sm text-gray-500 dark:text-zinc-400">
             Connect your emails to your Mail0 account
           </p>
         </div>
-        <div className="px-4 sm:px-16">
+        <div className="px-4 sm:px-0">
           {loading ? (
             <div className="flex justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-gray-500" />

--- a/app/api/v1/mail/connections/[connectionId]/route.ts
+++ b/app/api/v1/mail/connections/[connectionId]/route.ts
@@ -6,7 +6,7 @@ import { db } from "@/db";
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { connectionId: string } },
+  { params }: { params: Promise<{ connectionId: string }> },
 ) {
   try {
     const session = await auth.api.getSession({ headers: request.headers });
@@ -16,9 +16,11 @@ export async function DELETE(
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
 
+    const { connectionId } = await params;
+
     await db
       .delete(connection)
-      .where(and(eq(connection.id, params.connectionId), eq(connection.userId, userId)));
+      .where(and(eq(connection.id, connectionId), eq(connection.userId, userId)));
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/components/ui/nav-user.tsx
+++ b/components/ui/nav-user.tsx
@@ -40,7 +40,7 @@ export function NavUser() {
   const { data: session, refetch } = useSession();
   const router = useRouter();
   const { setTheme, theme } = useTheme();
-  const { data: connections, isLoading } = useConnections();
+  const { data: connections, isLoading, mutate } = useConnections();
 
   const activeAccount = useMemo(() => {
     if (!session) return null;
@@ -56,6 +56,7 @@ export function NavUser() {
         },
       })
       .then(refetch)
+      .then(() => mutate())
       .catch((err) => {
         toast.error("Error switching connection", {
           description: err.response.data.message,
@@ -75,14 +76,13 @@ export function NavUser() {
       return axios
         .delete(`/api/v1/mail/connections/${session.connectionId}`)
         .then(() => handleAccountSwitch(remainingConnections[0])())
-        .then(() => window.location.reload())
         .catch((err) => {
           toast.error("Error logging out", {
-            description: err.response?.data?.message || "Unknown error",
+            description: err.response?.data?.message,
           });
         });
     } else {
-      // No remaining accounts, proceed with full better-auth sign out
+      // No remaining accounts, delete connection and proceed with full better-auth sign out
       return toast.promise(
         axios.delete(`/api/v1/mail/connections/${session.connectionId}`).then(() =>
           signOut({

--- a/components/ui/nav-user.tsx
+++ b/components/ui/nav-user.tsx
@@ -63,6 +63,43 @@ export function NavUser() {
       });
   };
 
+  const handleLogout = () => {
+    if (!session) return;
+
+    const remainingConnections = connections?.filter(
+      (connection) => connection.id !== session.connectionId,
+    );
+
+    if (remainingConnections?.length) {
+      // Delete current connection and switch to the next
+      return axios
+        .delete(`/api/v1/mail/connections/${session.connectionId}`)
+        .then(() => handleAccountSwitch(remainingConnections[0])())
+        .then(() => window.location.reload())
+        .catch((err) => {
+          toast.error("Error logging out", {
+            description: err.response?.data?.message || "Unknown error",
+          });
+        });
+    } else {
+      // No remaining accounts, proceed with full better-auth sign out
+      return toast.promise(
+        axios.delete(`/api/v1/mail/connections/${session.connectionId}`).then(() =>
+          signOut({
+            fetchOptions: {
+              onSuccess: () => router.push("/"),
+            },
+          }),
+        ),
+        {
+          loading: "Signing out...",
+          success: "Signed out successfully!",
+          error: "Error signing out",
+        },
+      );
+    }
+  };
+
   return (
     <DropdownMenu>
       <SidebarMenu>
@@ -150,25 +187,7 @@ export function NavUser() {
               <Cog size={16} strokeWidth={2} className="opacity-60" aria-hidden="true" />
               Settings
             </DropdownMenuItem>
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onClick={async () => {
-                toast.promise(
-                  signOut({
-                    fetchOptions: {
-                      onSuccess: () => {
-                        router.push("/");
-                      },
-                    },
-                  }),
-                  {
-                    loading: "Signing out...",
-                    success: () => "Signed out successfully!",
-                    error: "Error signing out",
-                  },
-                );
-              }}
-            >
+            <DropdownMenuItem className="cursor-pointer" onClick={handleLogout}>
               <LogOut size={16} strokeWidth={2} className="opacity-60" aria-hidden="true" />
               Log out
             </DropdownMenuItem>


### PR DESCRIPTION
the better-auth logout function is currently strapped to the logout button on the nav sidebar. when triggered, it clears the user session even when multiple email accounts are logged in.

this introduces a `handleLogout` function to better handle the logout event.
It switches to the next account when multiple mail sessions exist and only triggers the better-auth logout when one account is left

![image](https://github.com/user-attachments/assets/ce704e91-cd15-4ffd-bafb-94a07b6d1574)
 