### PR TITLE
route back button on settings page back to previous mail folder 

### DIFF
--- a/app/(full-width)/contributors/page.tsx
+++ b/app/(full-width)/contributors/page.tsx
@@ -123,7 +123,7 @@ export default function OpenPage() {
                 <Button
                   asChild
                   variant="outline"
-                  className="border-neutral-800 bg-transparent text-white hover:bg-neutral-800 sm:hidden"
+                  className="bg-transparent text-neutral-800 dark:border-neutral-800 dark:text-white dark:hover:bg-neutral-800 sm:hidden"
                 >
                   <Link href="https://github.com/nizzyabi/mail0" target="_blank" className="gap-2">
                     <Github className="h-4 w-4" />

--- a/app/(routes)/settings/layout.tsx
+++ b/app/(routes)/settings/layout.tsx
@@ -2,6 +2,7 @@
 
 import { SettingsNavigation } from "./settings-navigation";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
@@ -9,6 +10,9 @@ import Link from "next/link";
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnPath = searchParams.get("from") || "/mail";
+  const mailPath = returnPath.startsWith("/settings") ? "/mail" : returnPath;
 
   return (
     <div className="flex min-h-screen w-full flex-col bg-background">
@@ -18,7 +22,7 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => router.back()}
+              onClick={() => router.push(mailPath)}
               className="gap-2 text-muted-foreground transition-colors hover:text-foreground"
             >
               <ArrowLeft className="h-4 w-4" />

--- a/app/(routes)/settings/settings-navigation.tsx
+++ b/app/(routes)/settings/settings-navigation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Settings, Mail, Shield, Palette, Keyboard, Bell } from "lucide-react";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 
@@ -46,6 +46,12 @@ const tabs = [
 
 export function SettingsNavigation() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const returnPath = searchParams.get("from");
+
+  const getHref = (tabHref: string) => {
+    return returnPath ? `${tabHref}?from=${returnPath}` : tabHref;
+  };
 
   return (
     <div className="flex flex-col md:w-80">
@@ -55,7 +61,7 @@ export function SettingsNavigation() {
           {tabs.map((tab) => (
             <Link
               key={tab.href}
-              href={tab.href}
+              href={getHref(tab.href)}
               className={cn(
                 "flex min-w-fit items-center gap-2 rounded-md px-4 py-2 text-sm font-medium",
                 pathname === tab.href
@@ -75,7 +81,7 @@ export function SettingsNavigation() {
         {tabs.map((tab) => (
           <Link
             key={tab.href}
-            href={tab.href}
+            href={getHref(tab.href)}
             className={cn(
               "group flex items-center gap-x-3 rounded-md p-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
               pathname === tab.href ? "bg-accent text-accent-foreground" : "text-muted-foreground",

--- a/components/ui/app-sidebar.tsx
+++ b/components/ui/app-sidebar.tsx
@@ -130,8 +130,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             suffix: ChevronDown,
             subItems: settingsPages.map((page) => ({
               title: page.title,
-              url: page.url,
-              isActive: pathname === page.url,
+              url: `${page.url}?from=${pathname}`,
             })),
           },
           // {


### PR DESCRIPTION
# refactor settings back button destination

since you can navigate to each settings tab driectly from the `/mail` route sidebar and you can easily switch between tabs while in the settings page, it makes sense to change the **Back** link to the previous /mail folder before navigating to the settings route

![tjeW9Mcj4C](https://github.com/user-attachments/assets/71eda66e-b188-46d3-83c2-00445fb3c67f)

## Additional fix
- fixed the github button light theme ligjht theme display
![msedge_IdwZrNUzlY](https://github.com/user-attachments/assets/d46fa539-4003-4e66-8463-675b3ae7a8a5)
![image](https://github.com/user-attachments/assets/4c9b6255-adcf-4b6f-9959-35a72cc191fe)
