### PR TITLE
RE:refactor back button destination in settings - Add Email!!

### DIFF
--- a/app/(routes)/settings/layout.tsx
+++ b/app/(routes)/settings/layout.tsx
@@ -12,7 +12,7 @@ import Link from "next/link";
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
   return (
     <Suspense fallback={<SettingsLayoutSkeleton />}>
-      <SettingsLayoutContent children={children} />
+      <SettingsLayoutContent>{children}</SettingsLayoutContent>
     </Suspense>
   );
 }

--- a/components/ui/nav-user.tsx
+++ b/components/ui/nav-user.tsx
@@ -11,8 +11,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SidebarMenu, SidebarMenuItem, SidebarMenuButton } from "@/components/ui/sidebar";
 import { useConnections } from "@/hooks/use-connections";
+import { usePathname, useRouter } from "next/navigation";
 import { signOut, useSession } from "@/lib/auth-client";
-import { useRouter } from "next/navigation";
 import { IConnection } from "@/types";
 import { useMemo } from "react";
 import Image from "next/image";
@@ -23,6 +23,7 @@ export function NavUser() {
   const { data: session, refetch } = useSession();
   const router = useRouter();
   const { data: connections, isLoading, mutate } = useConnections();
+  const pathname = usePathname();
 
   const activeAccount = useMemo(() => {
     if (!session) return null;
@@ -170,7 +171,7 @@ export function NavUser() {
               ))}
               <DropdownMenuItem
                 className="mt-1 cursor-pointer"
-                onClick={() => router.push("/settings/connections")}
+                onClick={() => router.push(`/settings/connections?from=${pathname}`)}
               >
                 <div className="flex items-center gap-2">
                   <UserPlus size={16} strokeWidth={2} className="opacity-60" aria-hidden="true" />


### PR DESCRIPTION
reference #201

The Add Email button under the account-switcher dropdown menu is another way to go into the settings page directly from the /mail route

this modification allows the settings page back button to restore the previous mail folder view if the user leaves the settings tab without adding a new email account

![msedge_hOV8BDkECy](https://github.com/user-attachments/assets/9923ca0b-dc57-48cf-a2fd-72ec0e8be18c)
