### PR TITLE
Fix: thread/mail display close button failing

### DIFF
--- a/components/mail/mail-display.tsx
+++ b/components/mail/mail-display.tsx
@@ -18,7 +18,7 @@ type Props = {
   index: number;
 };
 
-const MailDisplay = ({ emailData, isFullscreen, isMuted, isLoading, index }: Props) => {
+const MailDisplay = ({ emailData, isFullscreen, isMuted, index }: Props) => {
   const [isCollapsed, setIsCollapsed] = useState(true);
 
   useEffect(() => {

--- a/components/mail/thread-display.tsx
+++ b/components/mail/thread-display.tsx
@@ -50,7 +50,7 @@ export function ThreadDisplay({ mail, onClose, isMobile }: ThreadDisplayProps) {
 
   const handleClose = useCallback(() => {
     onClose?.();
-    setMail({ selected: null });
+    setMail({ selected: null, bulkSelected: [] });
   }, [onClose, setMail]);
 
   useEffect(() => {


### PR DESCRIPTION
 This fixes the page error that happens when you attempt to close the mail display window with the X button on the top left corner

![msedge_cnv8LlJRan](https://github.com/user-attachments/assets/04f70690-600e-4a5e-b3f3-c4d103f589c1)
