### PR TITLE
chore: move Google icon SVG from Login to Icons component

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { GitHub, Google } from "@/components/icons/icons";
 import { signIn, useSession } from "@/lib/auth-client";
-import { GitHub } from "@/components/icons/icons";
 import { Button } from "@/components/ui/button";
 import { CircleUserRound } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -52,12 +52,7 @@ export default function Login() {
             }}
             className="h-9 w-full bg-gradient-to-b from-primary/85 via-primary to-primary/85 hover:bg-primary/40"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
-              <path
-                fill="currentColor"
-                d="M11.99 13.9v-3.72h9.36c.14.63.25 1.22.25 2.05c0 5.71-3.83 9.77-9.6 9.77c-5.52 0-10-4.48-10-10S6.48 2 12 2c2.7 0 4.96.99 6.69 2.61l-2.84 2.76c-.72-.68-1.98-1.48-3.85-1.48c-3.31 0-6.01 2.75-6.01 6.12s2.7 6.12 6.01 6.12c3.83 0 5.24-2.65 5.5-4.22h-5.51z"
-              ></path>
-            </svg>
+            <Google />
             Log In with Google
           </Button>
           <Button

--- a/components/icons/icons.tsx
+++ b/components/icons/icons.tsx
@@ -40,6 +40,21 @@ export const Discord = ({ className }: { className?: string }) => (
   </svg>
 );
 
+export const Google = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    className={className}
+  >
+    <path
+      fill="currentColor"
+      d="M11.99 13.9v-3.72h9.36c.14.63.25 1.22.25 2.05c0 5.71-3.83 9.77-9.6 9.77c-5.52 0-10-4.48-10-10S6.48 2 12 2c2.7 0 4.96.99 6.69 2.61l-2.84 2.76c-.72-.68-1.98-1.48-3.85-1.48c-3.31 0-6.01 2.75-6.01 6.12s2.7 6.12 6.01 6.12c3.83 0 5.24-2.65 5.5-4.22h-5.51z"
+    ></path>
+  </svg>
+);
+
 export const GitHub = ({ className }: { className?: string }) => (
   <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className={className}>
     <title>GitHub</title>


### PR DESCRIPTION
### What does this PR do?
Moves the Google icon SVG from the `Login` page to a shared `Icons` component for better reusability and cleaner code structure.
